### PR TITLE
Change Cursor Awake() to public virtual void

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -147,7 +147,7 @@ namespace HoloToolkit.Unity.InputModule
 
         #region MonoBehaviour Functions
 
-        private void Awake()
+        public virtual void Awake()
         {
             originalDefaultCursorDistance = DefaultCursorDistance;
 


### PR DESCRIPTION
Base Cursor Awake function never gets called if another script (eg. InteractiveMeshCursor.cs) has an Awake function and derives from Cursor.cs

Overview
---


Changes
---
- Fixes: # .
